### PR TITLE
Updated to use Angular $digest

### DIFF
--- a/client/app/application.js
+++ b/client/app/application.js
@@ -1,17 +1,5 @@
 angular.module('forinlanguages', [
-  'ngRoute',
   'forinlanguages.services',
   'forinlanguages.peer'
 ])
-
-.config(function($routeProvider) {
-  $routeProvider
-    .when('/', {
-      templateUrl: 'app/views/main.html',
-      controller: 'PeerController',
-    })
-    .otherwise({
-      redirect: '/'
-    })
-})
 // Main app stuff here

--- a/client/app/application.js
+++ b/client/app/application.js
@@ -1,6 +1,17 @@
 angular.module('forinlanguages', [
+  'ngRoute',
   'forinlanguages.services',
   'forinlanguages.peer'
 ])
 
+.config(function($routeProvider) {
+  $routeProvider
+    .when('/', {
+      templateUrl: 'app/views/main.html',
+      controller: 'PeerController',
+    })
+    .otherwise({
+      redirect: '/'
+    })
+})
 // Main app stuff here

--- a/client/app/peer/peer.js
+++ b/client/app/peer/peer.js
@@ -5,16 +5,32 @@ angular.module('forinlanguages.peer', [])
   $scope.person = "";
   $scope.message = "";
   $scope.username = "";
+  $scope.me = {};
 
   // Object of connected peers and messages received/send
   $scope.peers = {};
   $scope.messages = [];
 
+  // $scope.$watch('peers', function(newVal, oldVal) {
+  //   console.log('detected change in peers obj');
+  //   $scope.peers = $scope.peers;
+  // });
+
+  // $scope.$watch('messages', function(newVal, oldVal) {
+  //   console.log('detected change in messages array');
+  //   $scope.messages = $scope.messages;
+  // });
+
+  // $scope.$watch('me', function(newVal, oldVal) {
+  //   console.log('detected change in me object');
+  //   $scope.me = $scope.me;
+  // });
+
   // Init peer instance for user
-  $scope.me = PeerFactory.makePeer($scope.me);
+  PeerFactory.makePeer($scope.me, $scope);
 
   $scope.me.on('connection', function(c) {
-    PeerFactory.handleConnection(c, $scope.peers, $scope.messages);
+    PeerFactory.handleConnection(c, $scope.peers, $scope.messages, $scope);
   });
 
   $scope.me.on('error', function(err) {
@@ -24,10 +40,7 @@ angular.module('forinlanguages.peer', [])
   $scope.connectTo = function() {
     var conn = PeerFactory.connectTo($scope.person, $scope.peers, $scope.me)
     conn.on('open', function() {
-      PeerFactory.handleConnection(conn, $scope.peers, $scope.messages);
-      console.log('connected to someone?');
-      console.log($scope.peers);
-      console.log("Length:", Object.keys($scope.peers).length);
+      PeerFactory.handleConnection(conn, $scope.peers, $scope.messages, $scope);
     });
     conn.on('error', function(err) { alert(err); });
   }
@@ -46,7 +59,6 @@ angular.module('forinlanguages.peer', [])
     };
     $scope.messages.push(dataToSend);
     PeerFactory.sendData(dataToSend, $scope.peers);
-    console.log('send data');
   };
 
   $window.onunload = $window.onbeforeunload = function(e) {

--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -2,37 +2,30 @@ angular.module('forinlanguages.services', [])
 
 .factory('PeerFactory', function() {
 
-  var makePeer = function(user, scope) {
+  var makePeer = function(cb) {
+    var newurl;
     var newPeer = new Peer({
       key: '6ph8w4mjh1cq5mi'
     });
     newPeer.on('open', function(id) {
       console.log("Opened with ID:", id);
+      newurl = "localhost:3000/p/" + id;
+      cb(newPeer, newurl);
     });
-      user = newPeer;
-    };
+  };
 
-  var handleConnection = function(c, peers, messages, scope) {
-    if(peers[c.peer] !== undefined) {
-      return console.log("That person is already connected!");
-    }
+  var handleConnection = function(c, msgCb, peerCb) {
     c.on('data', function(data) {
-      messages.push(data);
+      msgCb(data);
       c.on('close', function() {
-        delete peers[c.peer];
+        peerCb(c, true);
       });
     });
-    peers[c.peer] = c;
-    // Callback here
-    console.log("peers", peers);
+    peerCb(c, false);
   }
 
-  var connectTo = function(person, peers, me) {
-    var c = me.connect(person, {
-      metadata: {
-        peers: peers
-      }
-    });
+  var connectTo = function(person, me) {
+    var c = me.connect(person);
     return c;
   };
 

--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -2,31 +2,28 @@ angular.module('forinlanguages.services', [])
 
 .factory('PeerFactory', function() {
 
-  var makePeer = function(user) {
-    user = new Peer({
+  var makePeer = function(user, scope) {
+    var newPeer = new Peer({
       key: '6ph8w4mjh1cq5mi'
     });
-    user.on('open', function(id) {
+    newPeer.on('open', function(id) {
       console.log("Opened with ID:", id);
     });
-    return user;
-  }
+      user = newPeer;
+    };
 
-  var handleConnection = function(c, peers, messages) {
+  var handleConnection = function(c, peers, messages, scope) {
     if(peers[c.peer] !== undefined) {
       return console.log("That person is already connected!");
     }
-    console.log("Will connect")
     c.on('data', function(data) {
       messages.push(data);
-      console.log('received data', data);
-      console.log("messages:", messages);
       c.on('close', function() {
-        console.log('disconnected from person');
         delete peers[c.peer];
       });
     });
     peers[c.peer] = c;
+    // Callback here
     console.log("peers", peers);
   }
 

--- a/client/index.html
+++ b/client/index.html
@@ -27,6 +27,7 @@
     <button ng-click="connectTo()">Connect</button>
 
     <h3>My ID: {{ me.id }}</h3>
+    <h3>Your URL: {{ url }}</h3>
     <h3>Messages:</h3>
     <div class='chatArea' class="col-md-4">
       <form ng-submit ='sendData()'>


### PR DESCRIPTION
DOM elements didn't update unless Angular did a dirty check on an element. Adding $scope.$digest() forces Angular to go through its DOM cycle once called. This fixes our issue because we add data in an asynchronous fashion (i.e, we're only adding event listeners to our Peer Connection instances but the code inside of those listeners doesn't execute until the listener triggers).